### PR TITLE
Refactor/env-hosts

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,15 @@
+# Configuración básica de Django
+SECRET_KEY=tu_secret_key_aqui
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1,tu_ip_publica_aqui
+
+# Configuración de Base de Datos (PostgreSQL)
+DB_NAME=nombre_db
+DB_USER=usuario_db
+DB_PASSWORD=password_db
+DB_HOST=localhost
+DB_PORT=5432
+
+# API de TMDB
+API_KEY=tu_api_key_de_tmdb
+API_TOKEN=tu_api_token_de_tmdb

--- a/mymovies/settings.py
+++ b/mymovies/settings.py
@@ -33,7 +33,7 @@ SECRET_KEY = env('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['34.194.5.126']
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['localhost', '127.0.0.1'])
 print(ALLOWED_HOSTS)
 
 


### PR DESCRIPTION
## Objetivo
Este PR realiza un pequeño refactor en la configuración para evitar que el servidor "truene" en nuestras instancias si a alguien le falta configurar la IP en su entorno. Además, añade una plantilla para estandarizar las variables que necesita el proyecto.